### PR TITLE
Update nicer-fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Usage: bin [options] <file ...>
 
 `file` can be composed of multiple glob paths.
 
+## Special Thanks
+
+Special thanks to @RubenGarcia-sevenval for lot's of helpful debugging.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/commander": "^2.9.0",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
-    "nicer-fs": "^0.6.2",
+    "nicer-fs": "^0.6.3",
     "svg-sprite": "^1.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
The next version of `nicer-fs` contains a small fix where `writeFile` would throw if the folder already exists where the file should be written in.